### PR TITLE
Address PT-01 and provide identical exceptions

### DIFF
--- a/src/tagish/src/main/java/com/tagish/auth/DBLogin.java
+++ b/src/tagish/src/main/java/com/tagish/auth/DBLogin.java
@@ -69,7 +69,7 @@ public class DBLogin extends SimpleLogin
 
       if (!rsu.next()) {
         logEvent(con, username, AuditEventType.UserNotFound);
-        throw new FailedLoginException("Unknown user");
+        throw new FailedLoginException("Invalid username or password");
       }
       String upwd = rsu.getString(1);
       String tpwd = new String(password);
@@ -99,7 +99,7 @@ public class DBLogin extends SimpleLogin
         if (accountLocked || accountIsLocked(con, username)) {
           throw new AccountLockedException("Clients credentials have been revoked");
         } else {
-          throw new FailedLoginException("Bad password");
+          throw new FailedLoginException("Invalid username or password");
         }
       }
 


### PR DESCRIPTION
Prevent username enumeration by providing identical error messages regardless of whether it's a bad password or an unknown username.

![image](https://user-images.githubusercontent.com/1211146/103363641-970b3080-4a89-11eb-872f-d8ab947783c1.png)

![image](https://user-images.githubusercontent.com/1211146/103363647-9e323e80-4a89-11eb-831b-37fd36fcbb70.png)


## Changes Proposed

- Update exception message
-
-

## Security Considerations

Addresses finding PT-01
