### PR TITLE
update plugin to 3.4.8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/shibboleth-idp3-totp-auth"]
 	path = src/shibboleth-idp3-totp-auth
-	url = https://github.com/18F/Shibboleth-IdP3-TOTP-Auth.git
+	url = https://github.com/cloud-gov/Shibboleth-IdP3-TOTP-Auth.git


### PR DESCRIPTION
## Changes Proposed

Updates the totp plugin submodule to the latest commit.

Updates the submodule url to the cloud-gov org in github instead of 18f.

## Security Considerations

None.
