### PR TITLE
V3.4.8

### DIFF
--- a/src/tagish/build.gradle
+++ b/src/tagish/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.12'
 
     // For database connections
-    runtimeOnly 'org.postgresql:postgresql:42.2.20'
+    runtimeOnly 'org.postgresql:postgresql:9.4.1212'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:1.5.2'
     runtimeOnly 'mysql:mysql-connector-java:6.0.3'
     

--- a/src/tagish/src/main/java/com/tagish/auth/DBLogin.java
+++ b/src/tagish/src/main/java/com/tagish/auth/DBLogin.java
@@ -246,6 +246,7 @@ public class DBLogin extends SimpleLogin
       } catch (Exception e) {
         // Log the exception
         log.error("TROUBLE", e);
+        e.printStackTrace();
       }
     }
 


### PR DESCRIPTION
## Changes Proposed

- Rolls back the postgres driver to the last 9.4 (the newest would not start).
- attempts to print the entire stack trace on an exception

## Security Considerations

It would be better to have the driver updated more but it also needs to work.
