### PR TITLE
JasperListener is no longer required

### DIFF
--- a/jobs/idp/templates/config/tomcat/server.xml.erb
+++ b/jobs/idp/templates/config/tomcat/server.xml.erb
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <Server port="-1">
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
-  <Listener className="org.apache.catalina.core.JasperListener" />
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />


### PR DESCRIPTION
## Changes Proposed

- Removes the JasperListener from the tomcat 8 server.xml as it is no longer used. This is causing on error on startup.

## Security Considerations

None
