### PR TITLE
Update OpenJDK to latest version of Java 8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ apache-tomcat/apache-tomcat-8.5.65.tar.gz:
   size: 10523269
   object_id: 600190ee-43ec-4ec4-5193-93c2fdd36f33
   sha: sha256:a88ad17797320ebb56ef62426074579e6611228eb0c6571b3de549d55c096270
-java8/openjdk-1.8.0_141.tar.gz:
-  size: 45927906
-  object_id: 494fe8b9-a530-4f09-7eef-e89a98672e01
-  sha: fef57709d2ca0b375a3879fe03df303afe24307f
+java8/openjdk-1.8.302b08.tar.gz:
+  size: 105671701
+  object_id: 3329cc8e-b78d-4f5e-7b6e-9e01c8025888
+  sha: sha256:4dc37b36aa0e441363218951e31a9d2e5fc0e18cb84b9a1396e6efcbca4cb3ed
 shibboleth3/shibboleth-identity-provider-3.4.8.tar.gz:
   size: 47855645
   object_id: c973a918-b437-4db5-7647-58ad30b5abb2


### PR DESCRIPTION
This changeset updates the OpenJDK release to use the latest version of Java 8.  Big thanks to @ChrisMcGowan for all of the help!

## Changes Proposed:
- Updates OpenJDK to Java 8 (8u302)

## Security Considerations:
- This also added a new blob for the updated OpenJDK binary
- Helps us address recent security findings by keeping Java up-to-date