### PR TITLE
Update to java 11

### DIFF
--- a/jobs/idp/spec
+++ b/jobs/idp/spec
@@ -3,7 +3,7 @@ name: idp
 
 packages:
 - idp
-- openjdk-8
+- openjdk-11
 
 templates:
   bin/pre-start: bin/pre-start

--- a/jobs/idp/templates/bin/pre-start
+++ b/jobs/idp/templates/bin/pre-start
@@ -2,7 +2,7 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
-source /var/vcap/packages/openjdk-8/bosh/compile.env
+source /var/vcap/packages/openjdk-11/bosh/compile.env
 
 DATA_DIR=/var/vcap/data/idp
 

--- a/jobs/idp/templates/helpers/ctl_setup.sh
+++ b/jobs/idp/templates/helpers/ctl_setup.sh
@@ -75,7 +75,7 @@ then
   export PYTHONPATH=$WEBAPP_DIR/vendor/lib/python
 fi
 
-source /var/vcap/packages/openjdk-8/bosh/compile.env
+source /var/vcap/packages/openjdk-11/bosh/compile.env
 
 # setup CLASSPATH for all jars/ folders within packages
 export CLASSPATH=${CLASSPATH:-''} # default to empty

--- a/packages/idp/packaging
+++ b/packages/idp/packaging
@@ -5,7 +5,7 @@ set -u # report the usage of uninitialized variables
 # $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
-source /var/vcap/packages/openjdk-8/bosh/compile.env
+source /var/vcap/packages/openjdk-11/bosh/compile.env
 
 echo "Extracting tomcat archive..."
 mkdir -p tomcat

--- a/packages/idp/spec
+++ b/packages/idp/spec
@@ -1,7 +1,7 @@
 ---
 name: idp
 dependencies:
-- openjdk-8
+- openjdk-11
 files:
 - apache-tomcat/apache-tomcat-*.tar.gz
 - shibboleth3/shibboleth-identity-provider-*.tar.gz

--- a/packages/openjdk-11/spec.lock
+++ b/packages/openjdk-11/spec.lock
@@ -1,0 +1,2 @@
+name: openjdk-11
+fingerprint: c4b2f53750b5543e926aa1c7ff9796760ee5950fafa2b644417cbe48986aef6a

--- a/packages/openjdk-8/spec.lock
+++ b/packages/openjdk-8/spec.lock
@@ -1,2 +1,0 @@
-name: openjdk-8
-fingerprint: aa54a90747b077a3836b9f517ffb4c66fb9b867ba6620a9590bf6c479efbe7b4


### PR DESCRIPTION
## Changes Proposed

- Update to java 11

## Security Considerations

openjdk-11 is better-supported, so should have better response time if a CVE is discovered. Also, this is a requirement to update to idp4