### PR TITLE
drop loading messages when clicking buttons

### DIFF
--- a/jobs/idp/templates/views/login.vm.erb
+++ b/jobs/idp/templates/views/login.vm.erb
@@ -71,7 +71,6 @@
             #if ($passwordEnabled)
               <div class="form-element-wrapper">
                 <button class="form-element form-button" type="submit" name="_eventId_proceed"
-                    onClick="this.childNodes[0].nodeValue='#springMessageText("idp.login.pleasewait", "Logging in, please wait...")'"
                     >#springMessageText("idp.login.login", "Login")</button>
               </div>
             #end


### PR DESCRIPTION
These messages are kinda silly - browsers will move too fast to see them in most cases - and they use `onClick` which limits us to very permissive content security policies

## Changes proposed in this pull request:
- drop loading messages when clicking buttons


## security considerations
removing onclicks will let us improve our content security policies, which will improve security
