### PR TITLE
Add jdbc reconnect settings

### DIFF
--- a/jobs/idp/spec
+++ b/jobs/idp/spec
@@ -265,7 +265,7 @@ properties:
     example: "jdbc:postgresql://host/database"
   idp.jaas.database.testOnBorrow:
     description: "Validate the database connection before trying to use it"
-    default: "true"
+    default: true
   idp.jaas.database.dbUser:
     description: "Username for the authentication database"
   idp.jaas.database.dbPassword:

--- a/jobs/idp/spec
+++ b/jobs/idp/spec
@@ -263,6 +263,9 @@ properties:
   idp.jaas.database.dbURL:
     description: "JDBC URL of the database to use for authentication"
     example: "jdbc:postgresql://host/database"
+  idp.jaas.testOnBorrow:
+    description: "Validate the database connection before trying to use it"
+    default: "true"
   idp.jaas.database.dbUser:
     description: "Username for the authentication database"
   idp.jaas.database.dbPassword:

--- a/jobs/idp/spec
+++ b/jobs/idp/spec
@@ -263,7 +263,7 @@ properties:
   idp.jaas.database.dbURL:
     description: "JDBC URL of the database to use for authentication"
     example: "jdbc:postgresql://host/database"
-  idp.jaas.testOnBorrow:
+  idp.jaas.database.testOnBorrow:
     description: "Validate the database connection before trying to use it"
     default: "true"
   idp.jaas.database.dbUser:

--- a/jobs/idp/templates/config/shibboleth/authn/jaas.config
+++ b/jobs/idp/templates/config/shibboleth/authn/jaas.config
@@ -4,7 +4,7 @@ ShibUserPassAuth {
         dbURL="<%= p('idp.jaas.database.dbURL') %>"
         dbUser="<%= p('idp.jaas.database.dbUser') %>"
         dbPassword="<%= p('idp.jaas.database.dbPassword') %>"
-        testOnBorrow="true"
+        testOnBorrow="<%= p('idp.jaas.database.testOnBorrow') %>"
         userTable="<%= p('idp.jaas.database.userTable') %>"
         userColumn="<%= p('idp.jaas.database.userColumn') %>"
         passColumn="<%= p('idp.jaas.database.passColumn') %>"

--- a/jobs/idp/templates/config/shibboleth/authn/jaas.config
+++ b/jobs/idp/templates/config/shibboleth/authn/jaas.config
@@ -4,6 +4,7 @@ ShibUserPassAuth {
         dbURL="<%= p('idp.jaas.database.dbURL') %>"
         dbUser="<%= p('idp.jaas.database.dbUser') %>"
         dbPassword="<%= p('idp.jaas.database.dbPassword') %>"
+        testOnBorrow="true"
         userTable="<%= p('idp.jaas.database.userTable') %>"
         userColumn="<%= p('idp.jaas.database.userColumn') %>"
         passColumn="<%= p('idp.jaas.database.passColumn') %>"

--- a/jobs/idp/templates/config/shibboleth/authn/totp-authn-beans.xml.erb
+++ b/jobs/idp/templates/config/shibboleth/authn/totp-authn-beans.xml.erb
@@ -82,6 +82,7 @@
     <property name="url" value="<%= p('idp.totp.database.dbURL') %>"/>
     <property name="username" value="<%= p('idp.totp.database.dbUser') %>"/>
     <property name="password" value="<%= p('idp.totp.database.dbPassword') %>"/>
+    <property name="testOnBorrow" value="true"/>
   </bean>
 
   <!-- For SQLSeedFetcher -->

--- a/jobs/idp/templates/config/shibboleth/authn/totp-authn-beans.xml.erb
+++ b/jobs/idp/templates/config/shibboleth/authn/totp-authn-beans.xml.erb
@@ -82,7 +82,7 @@
     <property name="url" value="<%= p('idp.totp.database.dbURL') %>"/>
     <property name="username" value="<%= p('idp.totp.database.dbUser') %>"/>
     <property name="password" value="<%= p('idp.totp.database.dbPassword') %>"/>
-    <property name="testOnBorrow" value="true"/>
+    <property name="testOnBorrow" value="<%= p('idp.jaas.database.testOnBorrow') %>"/>
   </bean>
 
   <!-- For SQLSeedFetcher -->

--- a/jobs/idp/templates/config/shibboleth/global.xml.erb
+++ b/jobs/idp/templates/config/shibboleth/global.xml.erb
@@ -44,6 +44,6 @@
       p:url="<%= p('idp.jaas.database.dbURL') %>"
       p:username="<%= p('idp.jaas.database.dbUser') %>"
       p:password="<%= p('idp.jaas.database.dbPassword') %>" 
-      p.testOnBorrow="<%= p('idp.jaas.database.testOnBorrow') %>" />
+      p:testOnBorrow="<%= p('idp.jaas.database.testOnBorrow') %>" />
 
 </beans>

--- a/jobs/idp/templates/config/shibboleth/global.xml.erb
+++ b/jobs/idp/templates/config/shibboleth/global.xml.erb
@@ -43,6 +43,7 @@
       p:driverClassName="<%= p('idp.jaas.database.dbDriver') %>"
       p:url="<%= p('idp.jaas.database.dbURL') %>"
       p:username="<%= p('idp.jaas.database.dbUser') %>"
-      p:password="<%= p('idp.jaas.database.dbPassword') %>" />
+      p:password="<%= p('idp.jaas.database.dbPassword') %>" 
+      p.testOnBorrow="<%= p('idp.jaas.database.testOnBorrow') %>" />
 
 </beans>

--- a/templates/stub.yml
+++ b/templates/stub.yml
@@ -24,6 +24,7 @@ properties:
         dbURL: DATABASE_URL
         dbUser: DATABASE_USER
         dbPassword: DATABASE_URL
+        testOnBorrow: "true"
     port: PORT_NUMBER
     title: IDP_PAGE_TITLE
     footer: IDP_PAGE_FOOTER


### PR DESCRIPTION
## Changes Proposed

- Updated the code to use the testOnBorrow parameter to keep the connection searching during a disconnect
- Tested by creating a routing black hole for the RDS to force the idp to not respond, then delete the route and see that it does respond, simulating a database disconnect and connect. 

## Security Considerations

There are none, the code changed just looks for the database connection