### PR TITLE
Update database login to handle users with multiple origins

### DIFF
--- a/src/tagish/src/main/java/com/tagish/auth/DBLogin.java
+++ b/src/tagish/src/main/java/com/tagish/auth/DBLogin.java
@@ -61,10 +61,13 @@ public class DBLogin extends SimpleLogin
 
       psu = con.prepareStatement("SELECT " + passColumn + ", " + passLastModifiedColumn +
                     " FROM " + userTable +
-                    " WHERE " + userColumn + "=?" + where);
+                    " WHERE " + userColumn + "=?" +
+                    " AND " + originColumn + "=?" + where);
 
       /* Set the username to the statement */
       psu.setString(1, username);
+      /* Set the origin to the statement */
+      psu.setString(2, origin);
       rsu = psu.executeQuery();
 
       if (!rsu.next()) {
@@ -241,7 +244,7 @@ public class DBLogin extends SimpleLogin
         psu.setInt(2, eventType.getCode());
         psu.setTimestamp(3, now);
         psu.setString(4, origin);
-        psu.executeUpdate(); 
+        psu.executeUpdate();
       } catch (Exception e) {
         // Log the exception
         log.error("TROUBLE", e);


### PR DESCRIPTION
## Changes Proposed

We have lately noticed an issue where users in UAA with multiple origins (e.g. the origin from this Shibboleth IdP and an origin for the agency SSO) start having login failures on this IdP origin once they have a second UAA account on the agency origin.

In the logs for the login failures was this error:

```
javax.security.auth.login.FailedLoginException: Invalid username or password at 
com.tagish.auth.DBLogin.validateUser(DBLogin.java:102)
```

The line of code ultimately pointed to this BOSH release. And upon further investigation, it seems like the `validateUser`  method from that line is running a manual SQL query against the UAA database to get the user's username/password information and to determine if the username/password during login was correct.

But when a user has two origins, they would have two records in the UAA database, so it's possible that the SQL query could return the record for their agency origin and thus verify their login against the wrong password, resulting in the failures that some users are seeing.

To possibly fix the issue, I have updated the SQL query in the `validateUser` method to specify the origin for this shibboleth IdP when validating the user, which should ensure that it only ever attempts to validate a user against the correct origin.

## Security Considerations

There are no direct security considerations for users having two origins. But this fix may allow users to maintain a cloud.gov IdP account while switching over to their agency SSO, which would be helpful to them.
