### PR TITLE
Allstar - Add binary artifacts ignore paths

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,4 @@
+# Ignore reason: These files are required for the Gradle wrapper, which is used when building the project:
+# https://github.com/cloud-gov/shibboleth-boshrelease/blob/main/packages/idp/packaging#L24
+ignorePaths:
+- src/tagish/gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
## Changes proposed in this pull request:

- add configuration to ignore Gradle wrapper files for Allstar binary artifacts policy

## security considerations

We are excluding the configured files from Allstar's binary artifacts check since they are trusted Gradle files
