### PR TITLE
Fips endpoint

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -4,5 +4,5 @@ blobstore:
   options:
     bucket_name: cloud-gov-release-blobstore
     region: us-gov-west-1
-    endpoint: https://s3-us-gov-west-1.amazonaws.com
+    endpoint: https://s3-fips.us-gov-west-1.amazonaws.com
 final_name: shibboleth

--- a/config/final.yml
+++ b/config/final.yml
@@ -4,5 +4,5 @@ blobstore:
   options:
     bucket_name: cloud-gov-release-blobstore
     region: us-gov-west-1
-    endpoint: https://s3-fips.us-gov-west-1.amazonaws.com
+    host: s3-fips.us-gov-west-1.amazonaws.com
 final_name: shibboleth


### PR DESCRIPTION
## Changes Proposed

- Set the host property to the fips endpoint

## Security Considerations

Instructs bosh to use the fips 140 compliant fips endpoint when interacting with S3.
