### PR TITLE
133v3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,7 +6,7 @@ postgresql/postgresql-42.3.3.jar:
   size: 1039047
   object_id: fd1a7216-0b2b-4c9a-60b3-6f5898878944
   sha: sha256:eed0604f512ba44817954de99a07e2a5470aa4bfcb481d4e63a93e0ff0e0aede
-shibboleth4/shibboleth-identity-provider-4.3.3.tar.gz:
-  size: 60927078
-  object_id: 8b4a3f83-0a78-40e9-59b8-5eb565bcdf21
-  sha: sha256:815abe9c707c8741278eda8b9120be7d99f09238d2974ccc3a93b37d549cc149
+shibboleth4/shibboleth-identity-provider-4.2.1.tar.gz:
+  size: 55960112
+  object_id: 0b3baa4d-3773-45af-5369-25318b90fe63
+  sha: sha256:fa5e46d160f6b1bc50326c1a31627a05b5d0847b8f620d7f4c0251999b806474

--- a/src/tagish/build.gradle
+++ b/src/tagish/build.gradle
@@ -4,23 +4,23 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = "11"
-targetCompatibility = "11"
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     // For encryption
     implementation 'org.springframework.security:spring-security-crypto:4.1.2.RELEASE'
-    implementation 'org.slf4j:slf4j-api:2.0.12'
+    implementation 'org.slf4j:slf4j-api:1.7.12'
 
     // For database connections
     runtimeOnly 'org.postgresql:postgresql:42.2.20'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:1.5.2'
     runtimeOnly 'mysql:mysql-connector-java:6.0.3'
+    
 
-
-    testImplementation 'org.slf4j:jcl-over-slf4j:2.0.12'
-    testImplementation 'org.slf4j:jul-to-slf4j:2.0.12'
-    testImplementation 'org.slf4j:log4j-over-slf4j:2.0.12'
+    testImplementation 'org.slf4j:jcl-over-slf4j:1.7.12'
+    testImplementation 'org.slf4j:jul-to-slf4j:1.7.12'
+    testImplementation 'org.slf4j:log4j-over-slf4j:1.7.12'
     testImplementation 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
## Changes Proposed

- Rollback attempted upgrade to shibby idp 4.3.3 and corresponding gradle changes (get us back to v133)
- Leave tomcat bumped forward to 9.0.90 (what was added for v137)
- Part of https://github.com/cloud-gov/private/issues/2031

## Security Considerations

Attempting to patch for CVE

